### PR TITLE
Fix possible NaN return value in Analyser.getFrequenceRatio

### DIFF
--- a/src/Analyser.js
+++ b/src/Analyser.js
@@ -19,7 +19,7 @@ class Analyser {
 
   analyse = () => {
     this.analyser.getByteFrequencyData(this.frequences)
-    for(let i=0; i < this.frequences.length; i++){  
+    for(let i=0; i < this.frequences.length; i++){
       if(!this.hzHistory[i]){
         this.hzHistory[i] = []
       }
@@ -51,7 +51,8 @@ class Analyser {
     })
     const scale = max - min
     const actualValue = this.frequences[index] -min
-    const percentage = (actualValue/scale)
+    const percentage = scale === 0 ? (actualValue/scale) : 0;
+
     return this.startingScale + (this.pulseRatio * percentage)
   }
 


### PR DESCRIPTION
Im connecting an external `<audio>`-element and found that I was getting `NaN` ratio values passed to `Dancer.dance`. 

I traced it back to `Analyser.getFrequencyRatio` where `actualValue` would sometimes be divided by`scale` that would be 0. I don't know if this is the optimal fix, but it seems to work.

Thanks for a great lib!

