### PR TITLE
feat(dance): add font-size dance

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Here are the build in dances and their options
 + borderWidth
   + min : Minimum value given to `border-width`. Default: `0`
   + max : Maximum value given to `borderr-width`. Default: `5`
++ fontWidth
+  + min : Minimum value given to `font-width`. Default: `0.8`
+  + max : Maximum value given to `font-width`. Default: `1.2`
 
 To see each visual effect, you can go to the [Demo](https://okazari.github.io/Rythm.js/)
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Here are the build in dances and their options
 + borderWidth
   + min : Minimum value given to `border-width`. Default: `0`
   + max : Maximum value given to `borderr-width`. Default: `5`
-+ fontWidth
++ fontSize
   + min : Minimum value given to `font-width`. Default: `0.8`
   + max : Maximum value given to `font-width`. Default: `1.2`
 

--- a/src/Dancer.js
+++ b/src/Dancer.js
@@ -12,6 +12,7 @@ import blur, { reset as blurReset } from './dances/blur.js'
 import swing, { reset as swingReset } from './dances/swing.js'
 import neon, { reset as neonReset } from './dances/neon.js'
 import kern, { reset as kernReset } from './dances/kern.js'
+import fontSize, { reset as fontSizeReset } from './dances/font-size.js'
 import borderWidth, {
   reset as borderWidthReset,
 } from './dances/border-width.js'
@@ -34,6 +35,7 @@ class Dancer {
     this.registerDance('neon', neon, neonReset)
     this.registerDance('kern', kern, kernReset)
     this.registerDance('borderWidth', borderWidth, borderWidthReset)
+    this.registerDance('fontSize', fontSize, fontSizeReset)
   }
 
   registerDance(type, dance, reset = () => {}) {

--- a/src/dances/font-size.js
+++ b/src/dances/font-size.js
@@ -1,0 +1,10 @@
+export default (elem, value, options = {}) => {
+  const max = !isNaN(options.max) ? options.max : 0.8
+  const min = !isNaN(options.min) ? options.min : 1.2
+  const fontSize = (max - min) * value + min
+  elem.style.fontSize = `${fontSize}em`
+}
+
+export const reset = elem => {
+  elem.style.fontSize = '1em'
+}


### PR DESCRIPTION
Fix #66

Here is my contribution for adding `font-size` dance.
I played with `em` size to be relative of the default size.

Should I had an entry in the documentation ? 

