### PR TITLE
🐛Fix AudioContext suspended state due to Chrome new policy

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -84,7 +84,12 @@ class Player {
 
   start = () => {
     if (this.currentInputType === this.inputTypeList['TRACK']) {
-      this.audio.play()
+      if (this.audioCtx.state === 'suspended') {
+        this.audioCtx.resume()
+          .then(() => this.audio.play())
+      } else {
+        this.audio.play()
+      }
     }
   }
 


### PR DESCRIPTION
Since Chrome 62 there is a new policy that prevent autoplay, if the AudioContext is created without any user interaction (window.onload for example) the state will be set to "suspended" to prevent autoplay.

https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio

This fix will check the state before starting the song and resume the AudioContext if it's suspended.
Note : that will only work if the start method is called after a user action (ex: click on button).