### PR TITLE
Fixed Syntax Error

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             <div class="font__placeholder"></div>Font-color !
           </div>
           <pre class="prettyprint">
-            rythm.addRythm('fontColor2', 'color', 0, 10 {
+            rythm.addRythm('fontColor2', 'color', 0, 10, {
               from: [0,0,255],
               to:[255,0,255]
             })


### PR DESCRIPTION
There was a missing comma in one of the examples on the demo page (second fontColor, line 94) which would cause a syntax error. 